### PR TITLE
Add support for configuring multiple ServiceComm target versions in the .NET generator

### DIFF
--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/DefaultGenerationSettingsProvider.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/DefaultGenerationSettingsProvider.xtend
@@ -12,17 +12,19 @@ package com.btc.serviceidl.generator
 
 import com.btc.serviceidl.generator.common.ArtifactNature
 import com.btc.serviceidl.generator.common.ProjectType
+import com.btc.serviceidl.generator.cpp.CppConstants
 import com.btc.serviceidl.generator.cpp.IModuleStructureStrategy
 import com.btc.serviceidl.generator.cpp.IProjectSetFactory
+import com.btc.serviceidl.generator.cpp.ServiceCommVersion
 import com.btc.serviceidl.generator.cpp.prins.PrinsModuleStructureStrategy
 import com.btc.serviceidl.generator.cpp.prins.VSSolutionFactory
-import java.util.Arrays
-import java.util.HashSet
-import java.util.Set
-import java.util.Map
-import java.util.HashMap
-import com.btc.serviceidl.generator.cpp.CppConstants
+import com.btc.serviceidl.generator.dotnet.DotNetConstants
 import com.btc.serviceidl.generator.java.JavaConstants
+import java.util.Arrays
+import java.util.HashMap
+import java.util.HashSet
+import java.util.Map
+import java.util.Set
 
 class DefaultGenerationSettingsProvider implements IGenerationSettingsProvider
 {
@@ -44,6 +46,7 @@ class DefaultGenerationSettingsProvider implements IGenerationSettingsProvider
         val res = new HashMap<String, Set<String>>
         // TODO these should be registered by the respective generator plugins instead
         res.put(CppConstants.SERVICECOMM_VERSION_KIND, CppConstants.SERVICECOMM_VERSIONS)
+        res.put(DotNetConstants.SERVICECOMM_VERSION_KIND, DotNetConstants.SERVICECOMM_VERSIONS)
         res.put(JavaConstants.SERVICECOMM_VERSION_KIND, JavaConstants.SERVICECOMM_VERSIONS)
         return res.immutableCopy
     }
@@ -79,9 +82,11 @@ class DefaultGenerationSettingsProvider implements IGenerationSettingsProvider
         projectSetFactory = new VSSolutionFactory
         moduleStructureStrategy = new PrinsModuleStructureStrategy
         setVersion(CppConstants.SERVICECOMM_VERSION_KIND,
-            com.btc.serviceidl.generator.cpp.ServiceCommVersion.V0_12.label)
+            ServiceCommVersion.V0_12.label)
         setVersion(JavaConstants.SERVICECOMM_VERSION_KIND,
             com.btc.serviceidl.generator.java.ServiceCommVersion.V0_5.label)
+        setVersion(DotNetConstants.SERVICECOMM_VERSION_KIND,
+            com.btc.serviceidl.generator.dotnet.ServiceCommVersion.V0_6.label)
     }
 
     def getVersionKinds()

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/IdlGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/IdlGenerator.xtend
@@ -101,8 +101,8 @@ class IdlGenerator implements IGenerator2
         if (languages.contains(ArtifactNature.DOTNET))
         {
             val dotnet_generator = new DotNetGenerator
-            dotnet_generator.doGenerate(resource, fsa, qualified_name_provider, scope_provider, projectTypes,
-                if (protobuf_generator !== null)
+            dotnet_generator.doGenerate(resource, fsa, qualified_name_provider, scope_provider,
+                generation_settings_provider, projectTypes, if (protobuf_generator !== null)
                     protobuf_generator.getProjectReferences(ArtifactNature.DOTNET)
                 else
                     null)

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/BasicCSharpSourceGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/BasicCSharpSourceGenerator.xtend
@@ -10,6 +10,7 @@
 **********************************************************************/
 package com.btc.serviceidl.generator.dotnet
 
+import com.btc.serviceidl.generator.ITargetVersionProvider
 import com.btc.serviceidl.generator.common.GuidMapper
 import com.btc.serviceidl.idl.AbstractType
 import com.btc.serviceidl.idl.AliasDeclaration
@@ -44,6 +45,7 @@ import static extension com.btc.serviceidl.util.Extensions.*
 @Accessors(PACKAGE_GETTER)
 class BasicCSharpSourceGenerator {
     val extension TypeResolver typeResolver 
+    @Accessors(NONE) val ITargetVersionProvider targetVersionProvider
     val Map<String, String> typedef_table    
     val IDLSpecification idl
     
@@ -220,4 +222,9 @@ class BasicCSharpSourceGenerator {
    {
       '''/// «com.btc.serviceidl.util.Util.getPlainText(item).replaceAll("\\r", System.lineSeparator + "/// ")»'''
    }
+
+    protected def getTargetVersion()
+    {
+        ServiceCommVersion.get(targetVersionProvider.getTargetVersion(DotNetConstants.SERVICECOMM_VERSION_KIND))
+    }
 }

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/DotNetConstants.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/DotNetConstants.xtend
@@ -1,0 +1,19 @@
+/*********************************************************************
+ * \author see AUTHORS file
+ * \copyright 2015-2018 BTC Business Technology Consulting AG and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package com.btc.serviceidl.generator.dotnet;
+
+import java.util.Set
+
+class DotNetConstants
+{
+    public static val String SERVICECOMM_VERSION_KIND = "dotnet.servicecomm"
+    public static val Set<String> SERVICECOMM_VERSIONS = ServiceCommVersion.values.map[label].toSet.immutableCopy
+}

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/DotNetGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/DotNetGenerator.xtend
@@ -16,6 +16,7 @@
 
 package com.btc.serviceidl.generator.dotnet
 
+import com.btc.serviceidl.generator.IGenerationSettingsProvider
 import com.btc.serviceidl.generator.common.ArtifactNature
 import com.btc.serviceidl.generator.common.GeneratorUtil
 import com.btc.serviceidl.generator.common.Names
@@ -60,6 +61,7 @@ class DotNetGenerator
    private var IFileSystemAccess file_system_access
    private var IQualifiedNameProvider qualified_name_provider
    private var IScopeProvider scope_provider
+   var IGenerationSettingsProvider generationSettingsProvider
    private var IDLSpecification idl
    
    private var param_bundle = new ParameterBundle.Builder()
@@ -78,13 +80,15 @@ class DotNetGenerator
    private var extension BasicCSharpSourceGenerator basicCSharpSourceGenerator
     
    val paketDependencies = new HashSet<Pair<String, String>>
+    
    
-   def public void doGenerate(Resource res, IFileSystemAccess fsa, IQualifiedNameProvider qnp, IScopeProvider sp, Set<ProjectType> projectTypes, HashMap<String, HashMap<String, String>> pr)
+   def public void doGenerate(Resource res, IFileSystemAccess fsa, IQualifiedNameProvider qnp, IScopeProvider sp, IGenerationSettingsProvider generationSettingsProvider, Set<ProjectType> projectTypes, HashMap<String, HashMap<String, String>> pr)
    {
       resource = res
       file_system_access = fsa
       qualified_name_provider = qnp
       scope_provider = sp
+      this.generationSettingsProvider = generationSettingsProvider
       protobuf_project_references = pr
       
       idl = resource.contents.filter(IDLSpecification).head // only one IDL root module possible
@@ -309,7 +313,7 @@ class DotNetGenerator
             vsSolution,
             param_bundle.build
         )
-      basicCSharpSourceGenerator = new BasicCSharpSourceGenerator(typeResolver, typedef_table, idl)      
+      basicCSharpSourceGenerator = new BasicCSharpSourceGenerator(typeResolver, generationSettingsProvider, typedef_table, idl)      
    }
    
    private def void generateImpl(String src_root_path, InterfaceDeclaration interface_declaration)

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/ServiceCommVersion.java
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/ServiceCommVersion.java
@@ -1,0 +1,32 @@
+/*********************************************************************
+ * \author see AUTHORS file
+ * \copyright 2015-2018 BTC Business Technology Consulting AG and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package com.btc.serviceidl.generator.dotnet;
+
+public enum ServiceCommVersion {
+    V0_6("0.6");
+
+    private final String label;
+
+    ServiceCommVersion(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public static ServiceCommVersion get(String string) {
+        for (ServiceCommVersion value : values()) {
+            if (value.getLabel().equals(string)) return value;
+        }
+        throw new IllegalArgumentException("Unknown .NET ServiceComm version: " + string);
+    }
+}


### PR DESCRIPTION
Fixes #50

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btc-ag/service-idl/106)
<!-- Reviewable:end -->
