### PR TITLE
Fix cross-module project references in generated Java POMs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ nodeWs("azure-linux")
 	withMaven(maven: 'maven-default', publisherStrategy: 'EXPLICIT', options: [artifactsPublisher()])
 	{
 	    checkout scm
-		sh "mvn package"
+		sh "mvn package -U"
 		build job: '/cab/BF/serviceidl-integrationtests/master', 
 		      parameters: [string(name: 'build_project', value: env.JOB_NAME), string(name: 'build_id', value: env.BUILD_NUMBER), string(name: 'version', value: '')], 
 			  wait: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 nodeWs("azure-linux")
 {
-	withMaven(jdk: 'Java8', maven: 'maven-default', publisherStrategy: 'EXPLICIT', options: [artifactsPublisher()])
+	withMaven(maven: 'maven-default', publisherStrategy: 'EXPLICIT', options: [artifactsPublisher()])
 	{
 	    checkout scm
 		sh "mvn package"

--- a/com.btc.serviceidl.plainjava/pom.xml
+++ b/com.btc.serviceidl.plainjava/pom.xml
@@ -15,7 +15,7 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.2.4</version>
+                <version>2.2.5</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>

--- a/com.btc.serviceidl.tests/src/com/btc/serviceidl/tests/generator/cpp/CppGeneratorTest.xtend
+++ b/com.btc.serviceidl.tests/src/com/btc/serviceidl/tests/generator/cpp/CppGeneratorTest.xtend
@@ -180,6 +180,8 @@ class CppGeneratorTest extends AbstractGeneratorTest
             set(CAB_INT_SOURCE_DIR ${CMAKE_SOURCE_DIR})
             set(CAB_EXT_SOURCE_DIR ${CMAKE_SOURCE_DIR}/../)
             
+            add_definitions(-DBTC_CAB_COMMONS_FUTUREUTIL_STATIC_DEFINE)
+
             include(${CMAKE_CURRENT_LIST_DIR}/Infrastructure/ServiceHost/Demo/API/ServiceAPI/build/make.cmakeset)           
         ''', directory + "build/CMakeLists.txt", '''
             # define target name
@@ -295,6 +297,8 @@ class CppGeneratorTest extends AbstractGeneratorTest
             set(CAB_INT_SOURCE_DIR ${CMAKE_SOURCE_DIR})
             set(CAB_EXT_SOURCE_DIR ${CMAKE_SOURCE_DIR}/../)
             
+            add_definitions(-DBTC_CAB_COMMONS_FUTUREUTIL_STATIC_DEFINE)
+
             include(${CMAKE_CURRENT_LIST_DIR}/Infrastructure/ServiceHost/Demo/API/Dispatcher/build/make.cmakeset)
             include(${CMAKE_CURRENT_LIST_DIR}/Infrastructure/ServiceHost/Demo/API/Protobuf/build/make.cmakeset)
             include(${CMAKE_CURRENT_LIST_DIR}/Infrastructure/ServiceHost/Demo/API/ServiceAPI/build/make.cmakeset)

--- a/com.btc.serviceidl.tests/src/com/btc/serviceidl/tests/testdata/good/nested-module-in-non-empty-module2.idl
+++ b/com.btc.serviceidl.tests/src/com/btc/serviceidl/tests/testdata/good/nested-module-in-non-empty-module2.idl
@@ -1,0 +1,14 @@
+module Foo {
+
+   struct Bar
+   {
+      string field;
+   };
+
+   interface Test [guid=5AA8C2F8-04D6-4DFC-9FFE-7A15BDAE8B45]
+   {
+      Method1(in Bar bar) returns boolean;
+      Method2(in sequence<Bar> bar) returns boolean;
+   };
+
+}

--- a/com.btc.serviceidl.tests/src/com/btc/serviceidl/tests/testdata/good/nested-module-in-non-empty-module3.idl
+++ b/com.btc.serviceidl.tests/src/com/btc/serviceidl/tests/testdata/good/nested-module-in-non-empty-module3.idl
@@ -1,0 +1,13 @@
+module Foo {
+
+   struct Bar
+   {
+      string field;
+   };
+
+   interface Test [guid=5AA8C2F8-04D6-4DFC-9FFE-7A15BDAE8B45]
+   {
+      Method2(in sequence<Bar> bar) returns boolean;
+   };
+
+}

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/cpp/cmake/CMakeTopLevelProjectFileGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/cpp/cmake/CMakeTopLevelProjectFileGenerator.xtend
@@ -170,6 +170,11 @@ class CMakeTopLevelProjectFileGenerator
 
     def generateCMakeLists()
     {
+        // TODO defining BTC_CAB_COMMONS_FUTUREUTIL_STATIC_DEFINE is only a temporary addition
+        // which can be removed again when changing this to the new cmake-export style
+        val serviceCommTargetVersion = ServiceCommVersion.get(generationSettings.getTargetVersion(
+            CppConstants.SERVICECOMM_VERSION_KIND))
+
         '''
             cmake_minimum_required(VERSION 3.4)
             
@@ -186,6 +191,10 @@ class CMakeTopLevelProjectFileGenerator
             set(CAB_INT_SOURCE_DIR ${CMAKE_SOURCE_DIR})
             set(CAB_EXT_SOURCE_DIR ${CMAKE_SOURCE_DIR}/../)
             
+            «IF serviceCommTargetVersion == ServiceCommVersion.V0_12»
+                add_definitions(-DBTC_CAB_COMMONS_FUTUREUTIL_STATIC_DEFINE)
+            «ENDIF»
+
             «FOR projectPath : projectSet.projects.map[relativePath.toPortableString].sort»
                 include(${CMAKE_CURRENT_LIST_DIR}/«projectPath»/build/make.cmakeset)
             «ENDFOR»

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/java/InterfaceProjectGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/java/InterfaceProjectGenerator.xtend
@@ -49,15 +49,19 @@ class InterfaceProjectGenerator extends BasicProjectGenerator
         {
             val paramBundle = ParameterBundle.createBuilder(interfaceDeclaration.moduleStack).build
 
-            // record type aliases
-            val typeResolver = createTypeResolver(paramBundle)
-            for (typeAlias : interfaceDeclaration.contains.filter(AliasDeclaration))
-            {
-                typedefTable.computeIfAbsent(typeAlias.name, [typeResolver.resolve(typeAlias.type)])
-            }
-
             for (projectType : activeProjectTypes)
             {
+                // TODO this looks strange, better remove the state completely
+                dependencies.clear()
+
+                val typeResolver = createTypeResolver(paramBundle)
+
+                // record type aliases
+                for (typeAlias : interfaceDeclaration.contains.filter(AliasDeclaration))
+                {
+                    typedefTable.computeIfAbsent(typeAlias.name, [typeResolver.resolve(typeAlias.type)])
+                }
+    
                 generateProject(paramBundle, projectType, interfaceDeclaration)
                 generatePOM(interfaceDeclaration, projectType)
             }

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/java/ModuleProjectGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/java/ModuleProjectGenerator.xtend
@@ -23,6 +23,9 @@ class ModuleProjectGenerator extends BasicProjectGenerator
     {
         if (projectTypes.contains(ProjectType.COMMON))
         {
+            // TODO this looks strange, better remove the state completely
+            dependencies.clear()
+
             generateCommon(
                 makeProjectSourcePath(module, ProjectType.COMMON, MavenArtifactType.MAIN_JAVA, PathType.FULL), module)
 
@@ -31,6 +34,9 @@ class ModuleProjectGenerator extends BasicProjectGenerator
 
         if (projectTypes.contains(ProjectType.PROTOBUF))
         {
+            // TODO this looks strange, better remove the state completely
+            dependencies.clear()
+
             generateProtobuf(
                 makeProjectSourcePath(module, ProjectType.PROTOBUF, MavenArtifactType.MAIN_JAVA, PathType.FULL), module)
 

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/java/ProtobufUtil.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/java/ProtobufUtil.xtend
@@ -23,8 +23,8 @@ import com.btc.serviceidl.idl.FunctionDeclaration
 import com.btc.serviceidl.idl.InterfaceDeclaration
 import com.btc.serviceidl.idl.ModuleDeclaration
 import com.btc.serviceidl.idl.PrimitiveType
+import com.btc.serviceidl.idl.SequenceDeclaration
 import com.btc.serviceidl.util.Constants
-import com.btc.serviceidl.util.Util
 import com.google.common.base.CaseFormat
 import java.util.Optional
 import org.eclipse.emf.ecore.EObject
@@ -52,6 +52,11 @@ class ProtobufUtil
                 resolveProtobuf(typeResolver, object.referenceType, optProtobufType)
         // TODO really do nothing in case of collectionType?
         }
+        else if (object instanceof SequenceDeclaration)
+        {
+            throw new IllegalArgumentException(
+                "resolveProtobuf cannot be called with a SequenceDeclaration, dereference it at the call site")
+        }
         else
         {
             new ResolvedName(
@@ -62,14 +67,14 @@ class ProtobufUtil
 
     private static def String getLocalName(EObject object, Optional<ProtobufType> optProtobufType)
     {
-        if (object instanceof InterfaceDeclaration && Util.ensurePresentOrThrow(optProtobufType))
+        if (object instanceof InterfaceDeclaration && com.btc.serviceidl.util.Util.ensurePresentOrThrow(optProtobufType))
             getOuterClassName(object as InterfaceDeclaration) + Constants.SEPARATOR_PACKAGE + Names.plain(object) +
                 optProtobufType.get.getName
         else
         {
             val scopeDeterminant = object.scopeDeterminant
 
-            if (object instanceof FunctionDeclaration && Util.ensurePresentOrThrow(optProtobufType))
+            if (object instanceof FunctionDeclaration && com.btc.serviceidl.util.Util.ensurePresentOrThrow(optProtobufType))
                 Names.plain(scopeDeterminant) + "_" + optProtobufType.get.getName + "_" + Names.plain(object) +
                     optProtobufType.get.getName
             else

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/java/ProxyGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/java/ProxyGenerator.xtend
@@ -197,9 +197,9 @@ class ProxyGenerator
                      «val isByte = function.returnedType.isByte»
                      «val isShort = function.returnedType.isInt16»
                      «val isChar = function.returnedType.isChar»
-                     «val useCodec = GeneratorUtil.useCodec(function.returnedType.actualType, ArtifactNature.JAVA)»
-                     «val codec = if (useCodec) resolveCodec(function.returnedType.actualType, typeResolver) else null»
                      «val isSequence = function.returnedType.isSequenceType»
+                     «val useCodec = GeneratorUtil.useCodec(function.returnedType.actualType, ArtifactNature.JAVA) || isSequence»
+                     «val codec = if (useCodec) resolveCodec(function.returnedType.actualType, typeResolver) else null»
                      «val isFailable = isSequence && function.returnedType.isFailable»
                      «IF isSequence»
                          «returnType» result = «codec».decode«IF isFailable»Failable«ENDIF»(«responseName».get«protobufFunctionName»List());

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <properties>
         <project.scm.id>github.com</project.scm.id>
-        <tycho-version>1.1.0</tycho-version>
+        <tycho-version>1.2.0</tycho-version>
         <xtextVersion>2.13.0</xtextVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Fixes #204 

Also adapt C++ generator for latest BTC.CAB.ServiceComm version 0.12 to latest changes in BTC.CAB.Commons 1.9/testing.