### PR TITLE
Fixed #113: PRINS-3998: Add support for ServiceComm.NET 0.7

### DIFF
--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/DefaultGenerationSettingsProvider.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/DefaultGenerationSettingsProvider.xtend
@@ -91,7 +91,7 @@ class DefaultGenerationSettingsProvider implements IGenerationSettingsProvider
                 JavaConstants.SERVICECOMM_VERSION_KIND ->
                     com.btc.serviceidl.generator.java.ServiceCommVersion.V0_5.label,
                 DotNetConstants.SERVICECOMM_VERSION_KIND ->
-                    com.btc.serviceidl.generator.dotnet.ServiceCommVersion.V0_6.label}.entrySet
+                    com.btc.serviceidl.generator.dotnet.ServiceCommVersion.V0_7.label}.entrySet
 
             return result
         }

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/AppConfigGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/AppConfigGenerator.xtend
@@ -36,6 +36,8 @@ class AppConfigGenerator {
   // on Jenkins (but not on travis-ci)
   def CharSequence generateAppConfig(ModuleDeclaration module)
   {
+      val scv_V0_6 = getTargetVersion() == ServiceCommVersion.V0_6
+      
       '''
       <?xml version="1.0"?>
       <configuration>
@@ -55,6 +57,9 @@ class AppConfigGenerator {
           </context>
           <objects xmlns="http://www.springframework.net">
             <object id="BTC.CAB.Logging.API.NET.LoggerFactory" type="«typeResolver.resolve("BTC.CAB.Logging.Log4NET.Log4NETLoggerFactory").fullyQualifiedName», BTC.CAB.Logging.Log4NET"/>
+            «IF !scv_V0_6»
+               <object id="BTC.CAB.ServiceComm.NET.FaultHandling.ServiceFaultHandlerManagerFactory" type="«typeResolver.resolve("BTC.CAB.ServiceComm.NET.FaultHandling.ServiceFaultHandlerManagerFactory").fullyQualifiedName», BTC.CAB.ServiceComm.NET.FaultHandling"/>
+            «ENDIF»
             
             «IF parameterBundle.projectType == ProjectType.SERVER_RUNNER»
                «val protobufServerHelper = typeResolver.resolve("BTC.CAB.ServiceComm.NET.ProtobufUtil.ProtoBufServerHelper").fullyQualifiedName»
@@ -69,6 +74,9 @@ class AppConfigGenerator {
                  <constructor-arg index="0" ref="BTC.CAB.Logging.API.NET.LoggerFactory" />
                  <constructor-arg index="1" ref="BTC.CAB.ServiceComm.NET.SingleQueue.API.ConnectionFactory" />
                  <constructor-arg index="2" value="tcp://127.0.0.1:«Constants.DEFAULT_PORT»"/>
+                 «IF !scv_V0_6»
+                    <constructor-arg index="3" ref="BTC.CAB.ServiceComm.NET.FaultHandling.ServiceFaultHandlerManagerFactory"/>
+                 «ENDIF»
                </object>
 
                <object id="«protobufServerHelper»" type="«protobufServerHelper», BTC.CAB.ServiceComm.NET.ProtobufUtil"/>
@@ -113,6 +121,9 @@ class AppConfigGenerator {
                  <constructor-arg index="0" ref="BTC.CAB.Logging.API.NET.LoggerFactory" />
                  <constructor-arg index="1" ref="BTC.CAB.ServiceComm.NET.SingleQueue.API.ConnectionFactory" />
                  <constructor-arg index="2" value="tcp://127.0.0.1:«Constants.DEFAULT_PORT»"/>
+                 «IF !scv_V0_6»
+                    <constructor-arg index="3" ref="BTC.CAB.ServiceComm.NET.FaultHandling.ServiceFaultHandlerManagerFactory"/>
+                 «ENDIF»
                </object>
             «ENDIF»
             

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/AppConfigGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/AppConfigGenerator.xtend
@@ -36,7 +36,7 @@ class AppConfigGenerator {
   // on Jenkins (but not on travis-ci)
   def CharSequence generateAppConfig(ModuleDeclaration module)
   {
-      val scv_V0_6 = getTargetVersion() == ServiceCommVersion.V0_6
+      val serviceCommVersion_V0_6 = getTargetVersion() == ServiceCommVersion.V0_6
       
       '''
       <?xml version="1.0"?>
@@ -57,7 +57,7 @@ class AppConfigGenerator {
           </context>
           <objects xmlns="http://www.springframework.net">
             <object id="BTC.CAB.Logging.API.NET.LoggerFactory" type="«typeResolver.resolve("BTC.CAB.Logging.Log4NET.Log4NETLoggerFactory").fullyQualifiedName», BTC.CAB.Logging.Log4NET"/>
-            «IF !scv_V0_6»
+            «IF !serviceCommVersion_V0_6»
                <object id="BTC.CAB.ServiceComm.NET.FaultHandling.ServiceFaultHandlerManagerFactory" type="«typeResolver.resolve("BTC.CAB.ServiceComm.NET.FaultHandling.ServiceFaultHandlerManagerFactory").fullyQualifiedName», BTC.CAB.ServiceComm.NET.FaultHandling"/>
             «ENDIF»
             
@@ -74,7 +74,7 @@ class AppConfigGenerator {
                  <constructor-arg index="0" ref="BTC.CAB.Logging.API.NET.LoggerFactory" />
                  <constructor-arg index="1" ref="BTC.CAB.ServiceComm.NET.SingleQueue.API.ConnectionFactory" />
                  <constructor-arg index="2" value="tcp://127.0.0.1:«Constants.DEFAULT_PORT»"/>
-                 «IF !scv_V0_6»
+                 «IF !serviceCommVersion_V0_6»
                     <constructor-arg index="3" ref="BTC.CAB.ServiceComm.NET.FaultHandling.ServiceFaultHandlerManagerFactory"/>
                  «ENDIF»
                </object>
@@ -121,7 +121,7 @@ class AppConfigGenerator {
                  <constructor-arg index="0" ref="BTC.CAB.Logging.API.NET.LoggerFactory" />
                  <constructor-arg index="1" ref="BTC.CAB.ServiceComm.NET.SingleQueue.API.ConnectionFactory" />
                  <constructor-arg index="2" value="tcp://127.0.0.1:«Constants.DEFAULT_PORT»"/>
-                 «IF !scv_V0_6»
+                 «IF !serviceCommVersion_V0_6»
                     <constructor-arg index="3" ref="BTC.CAB.ServiceComm.NET.FaultHandling.ServiceFaultHandlerManagerFactory"/>
                  «ENDIF»
                </object>

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/DispatcherGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/DispatcherGenerator.xtend
@@ -35,7 +35,7 @@ class DispatcherGenerator extends ProxyDispatcherGeneratorBase {
       val protobufRequest = getProtobufRequestClassName(interfaceDeclaration)
       val protobuf_response = getProtobufResponseClassName(interfaceDeclaration)
       val serviceFaultHandler = "serviceFaultHandler"
-      val scv_V0_6 = getTargetVersion() == ServiceCommVersion.V0_6
+      val serviceCommVersion_V0_6 = getTargetVersion() == ServiceCommVersion.V0_6
       
       // special case: the ServiceComm type InvalidRequestReceivedException has
       // the namespace BTC.CAB.ServiceComm.NET.API.Exceptions, but is included
@@ -84,13 +84,13 @@ class DispatcherGenerator extends ProxyDispatcherGeneratorBase {
         «ENDFOR»
         
         /// <see cref="BTC.CAB.ServiceComm.NET.API.IServiceDispatcher.ProcessRequest"/>
-        «IF scv_V0_6»
+        «IF serviceCommVersion_V0_6»
             public override «resolve("BTC.CAB.ServiceComm.NET.Common.IMessageBuffer")» ProcessRequest(IMessageBuffer requestBuffer, «resolve("BTC.CAB.ServiceComm.NET.Common.IPeerIdentity")» peerIdentity)
         «ELSE»
             public override «resolve("System.Byte[]")» ProcessRequest(byte[] requestBuffer, «resolve("BTC.CAB.ServiceComm.NET.Common.IPeerIdentity")» peerIdentity)
         «ENDIF»
         {
-           «IF scv_V0_6»
+           «IF serviceCommVersion_V0_6»
                var request = «protobufRequest».ParseFrom(requestBuffer.PopFront());
            «ELSE»
                var request = «protobufRequest».ParseFrom(requestBuffer);
@@ -147,7 +147,7 @@ class DispatcherGenerator extends ProxyDispatcherGeneratorBase {
                  ;
               
               var response = «protobuf_response».CreateBuilder().Set«func.name.asDotNetProtobufName»Response(responseBuilder).Build();
-              «IF scv_V0_6»
+              «IF serviceCommVersion_V0_6»
                   return new «resolve("BTC.CAB.ServiceComm.NET.Common.MessageBuffer")»(response.ToByteArray());
               «ELSE»
                   return response.ToByteArray();

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/DispatcherGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/DispatcherGenerator.xtend
@@ -35,6 +35,7 @@ class DispatcherGenerator extends ProxyDispatcherGeneratorBase {
       val protobufRequest = getProtobufRequestClassName(interfaceDeclaration)
       val protobuf_response = getProtobufResponseClassName(interfaceDeclaration)
       val serviceFaultHandler = "serviceFaultHandler"
+      val scv_V0_6 = getTargetVersion() == ServiceCommVersion.V0_6
       
       // special case: the ServiceComm type InvalidRequestReceivedException has
       // the namespace BTC.CAB.ServiceComm.NET.API.Exceptions, but is included
@@ -83,9 +84,17 @@ class DispatcherGenerator extends ProxyDispatcherGeneratorBase {
         «ENDFOR»
         
         /// <see cref="BTC.CAB.ServiceComm.NET.API.IServiceDispatcher.ProcessRequest"/>
-        public override «resolve("BTC.CAB.ServiceComm.NET.Common.IMessageBuffer")» ProcessRequest(IMessageBuffer requestBuffer, «resolve("BTC.CAB.ServiceComm.NET.Common.IPeerIdentity")» peerIdentity)
+        «IF scv_V0_6»
+            public override «resolve("BTC.CAB.ServiceComm.NET.Common.IMessageBuffer")» ProcessRequest(IMessageBuffer requestBuffer, «resolve("BTC.CAB.ServiceComm.NET.Common.IPeerIdentity")» peerIdentity)
+        «ELSE»
+            public override «resolve("System.Byte[]")» ProcessRequest(byte[] requestBuffer, «resolve("BTC.CAB.ServiceComm.NET.Common.IPeerIdentity")» peerIdentity)
+        «ENDIF»
         {
-           var request = «protobufRequest».ParseFrom(requestBuffer.PopFront());
+           «IF scv_V0_6»
+               var request = «protobufRequest».ParseFrom(requestBuffer.PopFront());
+           «ELSE»
+               var request = «protobufRequest».ParseFrom(requestBuffer);
+           «ENDIF»
            
            «FOR func : interfaceDeclaration.functions»
            «val requestName = func.name.asDotNetProtobufName + Constants.PROTOBUF_REQUEST»
@@ -138,7 +147,11 @@ class DispatcherGenerator extends ProxyDispatcherGeneratorBase {
                  ;
               
               var response = «protobuf_response».CreateBuilder().Set«func.name.asDotNetProtobufName»Response(responseBuilder).Build();
-              return new «resolve("BTC.CAB.ServiceComm.NET.Common.MessageBuffer")»(response.ToByteArray());
+              «IF scv_V0_6»
+                  return new «resolve("BTC.CAB.ServiceComm.NET.Common.MessageBuffer")»(response.ToByteArray());
+              «ELSE»
+                  return response.ToByteArray();
+              «ENDIF»
            }
            «ENDFOR»
 

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/DotNetGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/DotNetGenerator.xtend
@@ -90,8 +90,6 @@ class DotNetGenerator
         this.qualifiedNameProvider = qualifiedNameProvider
         this.generationSettings = generationSettings
         this.protobufProjectReferences = protobufProjectReferences
-        this.nugetPackages = new NuGetPackageResolver(ServiceCommVersion.get(generationSettings.getTargetVersion(
-            DotNetConstants.SERVICECOMM_VERSION_KIND)))
     }
 
     def void doGenerate()

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/DotNetGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/DotNetGenerator.xtend
@@ -67,12 +67,12 @@ class DotNetGenerator
    val IGenerationSettings generationSettings
    val IDLSpecification idl
    
+   var NuGetPackageResolver nugetPackages
    var ParameterBundle paramBundle
    
    val typedefTable = new HashMap<String, String>
    val namespaceReferences = new HashSet<String>
    val failableAliases = new HashSet<FailableAlias>
-   var nugetPackages = new NuGetPackageResolver
    val vsSolution = new VSSolution
    val csFiles = new HashSet<String>
    val protobufFiles = new HashSet<String>
@@ -90,6 +90,8 @@ class DotNetGenerator
         this.qualifiedNameProvider = qualifiedNameProvider
         this.generationSettings = generationSettings
         this.protobufProjectReferences = protobufProjectReferences
+        this.nugetPackages = new NuGetPackageResolver(ServiceCommVersion.get(generationSettings.getTargetVersion(
+            DotNetConstants.SERVICECOMM_VERSION_KIND)))
     }
 
     def void doGenerate()
@@ -347,7 +349,8 @@ class DotNetGenerator
       reinitializeFile
       paramBundle = ParameterBundle.createBuilder(paramBundle.moduleStack).with(projectType).build
       protobufFiles.clear
-      nugetPackages = new NuGetPackageResolver
+      nugetPackages = new NuGetPackageResolver(ServiceCommVersion.get(generationSettings.getTargetVersion(
+            DotNetConstants.SERVICECOMM_VERSION_KIND)))
       csFiles.clear
       
       val typeResolver = new TypeResolver(

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/NuGetPackageResolver.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/NuGetPackageResolver.xtend
@@ -16,17 +16,37 @@
 package com.btc.serviceidl.generator.dotnet
 
 import java.util.HashSet
+import java.util.List
 
 class NuGetPackageResolver
 {
+    ServiceCommVersion serviceCommTargetVersion
+    
+    new(ServiceCommVersion serviceCommTargetVersion){
+        this.serviceCommTargetVersion = serviceCommTargetVersion
+    }
     // TODO the versions should probably not be fixed to a specific micro version, but use something like "1.2.latest", in the
     // format used by nuget/paket
     
     // ******************************* PLEASE ALWAYS KEEP THIS LIST ALPHABETICALLY SORTED !!! ******************************* //
-    static val versionMapper = #{
+    // ServiceComm 0.6
+    static val versionMapper_0_6 = #{
         "BTC.CAB.Commons" -> "1.8.7",
         "BTC.CAB.Logging" -> "1.7.2",
         "BTC.CAB.ServiceComm.NET" -> "0.6.0",
+        "CommandLineParser" -> "1.9.71",
+        "Google.ProtocolBuffers" -> "2.4.1.555",
+        "log4net" -> "1.2.13",
+        "NUnit" -> "2.6.4", // TODO specifying 2.6.5 here generates a dependency conflict, but I don't understand why 
+        "Spring.Core" -> "1.3.2",
+        "Common.Logging" -> "1.2.0"
+    }
+
+    // ServiceComm 0.7
+    static val versionMapper_0_7 = #{
+        "BTC.CAB.Commons" -> "1.8.7",
+        "BTC.CAB.Logging" -> "1.7.2",
+        "BTC.CAB.ServiceComm.NET" -> "0.7.0",
         "CommandLineParser" -> "1.9.71",
         "Google.ProtocolBuffers" -> "2.4.1.555",
         "log4net" -> "1.2.13",
@@ -62,11 +82,21 @@ class NuGetPackageResolver
 
     val nugetPackages = new HashSet<NuGetPackage>
 
-    private static def NuGetPackage resolvePackageInternal(String assemblyName)
+    private def NuGetPackage resolvePackageInternal(String assemblyName)
     {
-        val versions = validOrThrow(packageMapper.get(assemblyName), assemblyName, "package ID").map [
-            new Pair(it, validOrThrow(versionMapper.get(it), it, "package version"))
-        ].toList
+        var List<Pair<String, String>> versions = null
+        if (serviceCommTargetVersion == ServiceCommVersion.V0_6)
+        {
+            versions = validOrThrow(packageMapper.get(assemblyName), assemblyName, "package ID").map [
+                new Pair(it, validOrThrow(versionMapper_0_6.get(it), it, "package version"))
+            ].toList
+        }
+        if (serviceCommTargetVersion == ServiceCommVersion.V0_7)
+        {
+            versions = validOrThrow(packageMapper.get(assemblyName), assemblyName, "package ID").map [
+                new Pair(it, validOrThrow(versionMapper_0_7.get(it), it, "package version"))
+            ].toList
+        }
         // TODO probably, this must be generalized, depending on the .NET version. but is this necessary at all? 
         // isn't the hint path filled by nuget or paket?
         // TODO the assembly path with paket doesn't contain the version number, but it probably does when nu-get is used

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/ProxyGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/ProxyGenerator.xtend
@@ -34,7 +34,7 @@ class ProxyGenerator extends ProxyDispatcherGeneratorBase {
       if (featureProfile.usesEvents)
          resolve("BTC.CAB.ServiceComm.NET.Util.EventRegistryExtensions")
       val serviceFaultHandler = "serviceFaultHandler"
-      val scv_V0_6 = getTargetVersion() == ServiceCommVersion.V0_6
+      val serviceCommVersion_V0_6 = getTargetVersion() == ServiceCommVersion.V0_6
       
       '''
       public class «className» : «apiFullyQualifiedName.shortName»
@@ -88,13 +88,13 @@ class ProxyGenerator extends ProxyDispatcherGeneratorBase {
                   «ENDFOR»
                   
                «ENDIF»
-               «IF scv_V0_6»
+               «IF serviceCommVersion_V0_6»
                     var result =_serviceReference.RequestAsync(new «resolve("BTC.CAB.ServiceComm.NET.Common.MessageBuffer")»(protobufRequest.ToByteArray())).ContinueWith(task =>
                «ELSE»
                     var result =_serviceReference.RequestAsync(protobufRequest.ToByteArray()).ContinueWith(task =>
                «ENDIF»
                {
-                  «IF scv_V0_6»
+                  «IF serviceCommVersion_V0_6»
                      «apiResponseName» response = «apiResponseName».ParseFrom(task.Result.PopFront());
                   «ELSE»
                      «apiResponseName» response = «apiResponseName».ParseFrom(task.Result);

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/ProxyGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/ProxyGenerator.xtend
@@ -34,6 +34,7 @@ class ProxyGenerator extends ProxyDispatcherGeneratorBase {
       if (featureProfile.usesEvents)
          resolve("BTC.CAB.ServiceComm.NET.Util.EventRegistryExtensions")
       val serviceFaultHandler = "serviceFaultHandler"
+      val scv_V0_6 = getTargetVersion() == ServiceCommVersion.V0_6
       
       '''
       public class «className» : «apiFullyQualifiedName.shortName»
@@ -87,9 +88,17 @@ class ProxyGenerator extends ProxyDispatcherGeneratorBase {
                   «ENDFOR»
                   
                «ENDIF»
-               var result =_serviceReference.RequestAsync(new «resolve("BTC.CAB.ServiceComm.NET.Common.MessageBuffer")»(protobufRequest.ToByteArray())).ContinueWith(task =>
+               «IF scv_V0_6»
+                    var result =_serviceReference.RequestAsync(new «resolve("BTC.CAB.ServiceComm.NET.Common.MessageBuffer")»(protobufRequest.ToByteArray())).ContinueWith(task =>
+               «ELSE»
+                    var result =_serviceReference.RequestAsync(protobufRequest.ToByteArray()).ContinueWith(task =>
+               «ENDIF»
                {
-                  «apiResponseName» response = «apiResponseName».ParseFrom(task.Result.PopFront());
+                  «IF scv_V0_6»
+                     «apiResponseName» response = «apiResponseName».ParseFrom(task.Result.PopFront());
+                  «ELSE»
+                     «apiResponseName» response = «apiResponseName».ParseFrom(task.Result);
+                  «ENDIF»
                   «val isFailable = com.btc.serviceidl.util.Util.isFailable(function.returnedType)»
                   «val useCodec = isFailable || GeneratorUtil.useCodec(function.returnedType.actualType, ArtifactNature.DOTNET)»
                   «val useCast = useCodec && !isFailable»

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/ServiceCommVersion.java
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/ServiceCommVersion.java
@@ -11,7 +11,8 @@
 package com.btc.serviceidl.generator.dotnet;
 
 public enum ServiceCommVersion {
-    V0_6("0.6");
+    V0_6("0.6"),
+    V0_7("0.7");
 
     private final String label;
 

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/TestGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/TestGenerator.xtend
@@ -31,7 +31,7 @@ class TestGenerator extends GeneratorBase
         val serviceFaultHandlerManagerFactory = resolve("BTC.CAB.ServiceComm.NET.FaultHandling.ServiceFaultHandlerManagerFactory")
         val serverRegistration = getServerRegistrationName(interfaceDeclaration)
         val connectionFactory = resolve("BTC.CAB.ServiceComm.NET.SingleQueue.ZeroMQ.NetMQ.NetMqConnectionFactory")
-        val scv_V0_6 = getTargetVersion() == ServiceCommVersion.V0_6
+        val serviceCommVersion_V0_6 = getTargetVersion() == ServiceCommVersion.V0_6
 
         // explicit resolution of necessary assemblies
         resolve("BTC.CAB.Logging.API.NET.ILoggerFactory")
@@ -60,26 +60,26 @@ class TestGenerator extends GeneratorBase
                   const «resolve("System.string")» connectionString = "tcp://127.0.0.1:«Constants.DEFAULT_PORT»";
                   
                   var loggerFactory = new «loggerFactory»();
-                  «IF !scv_V0_6»
+                  «IF !serviceCommVersion_V0_6»
                       var serviceFaultHandlerManagerFactory = new «serviceFaultHandlerManagerFactory»();
                   «ENDIF»
                   
                   // server
-                  StartServer(loggerFactory«IF !scv_V0_6», serviceFaultHandlerManagerFactory«ENDIF», connectionString);
+                  StartServer(loggerFactory«IF !serviceCommVersion_V0_6», serviceFaultHandlerManagerFactory«ENDIF», connectionString);
                   
                   // client
                   var connectionOptions = «connectionFactory».«resolve("BTC.CAB.ServiceComm.NET.SingleQueue.ZeroMQ.API.ConnectionOptions").alias("DefaultClientConnectionOptions")»;
                   «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.API.IConnectionFactory")» connectionFactory = new «connectionFactory»(connectionOptions, loggerFactory);
-                  _client = new «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.Core.Client")»(connectionString, new «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.Core.AsyncRpcClientEndpoint")»(loggerFactory«IF !scv_V0_6», serviceFaultHandlerManagerFactory«ENDIF»), connectionFactory);
+                  _client = new «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.Core.Client")»(connectionString, new «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.Core.AsyncRpcClientEndpoint")»(loggerFactory«IF !serviceCommVersion_V0_6», serviceFaultHandlerManagerFactory«ENDIF»), connectionFactory);
                   
                   _testSubject = «resolve(interfaceDeclaration, ProjectType.PROXY).alias(getProxyFactoryName(interfaceDeclaration))».CreateProtobufProxy(_client.ClientEndpoint);
                }
             
-               private void StartServer(«loggerFactory» loggerFactory«IF !scv_V0_6», «serviceFaultHandlerManagerFactory» serviceFaultHandlerManagerFactory«ENDIF», string connectionString)
+               private void StartServer(«loggerFactory» loggerFactory«IF !serviceCommVersion_V0_6», «serviceFaultHandlerManagerFactory» serviceFaultHandlerManagerFactory«ENDIF», string connectionString)
                {
                    var connectionOptions = «connectionFactory».«resolve("BTC.CAB.ServiceComm.NET.SingleQueue.ZeroMQ.API.ConnectionOptions").alias("DefaultServerConnectionOptions")»;
                   _serverConnectionFactory = new «connectionFactory»(connectionOptions, loggerFactory);
-                  _server = new Server(connectionString, new «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.Core.AsyncRpcServerEndpoint")»(loggerFactory«IF !scv_V0_6», serviceFaultHandlerManagerFactory«ELSE»«ENDIF»), _serverConnectionFactory);
+                  _server = new Server(connectionString, new «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.Core.AsyncRpcServerEndpoint")»(loggerFactory«IF !serviceCommVersion_V0_6», serviceFaultHandlerManagerFactory«ELSE»«ENDIF»), _serverConnectionFactory);
                   _serverRegistration = new «serverRegistration»(_server);
                   _serverRegistration.RegisterService();
                   // ensure that the server runs when the client is created.

--- a/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/TestGenerator.xtend
+++ b/com.btc.serviceidl/src/com/btc/serviceidl/generator/dotnet/TestGenerator.xtend
@@ -28,11 +28,14 @@ class TestGenerator extends GeneratorBase
     {
         val apiClassName = resolve(interfaceDeclaration)
         val loggerFactory = resolve("BTC.CAB.Logging.Log4NET.Log4NETLoggerFactory")
+        val serviceFaultHandlerManagerFactory = resolve("BTC.CAB.ServiceComm.NET.FaultHandling.ServiceFaultHandlerManagerFactory")
         val serverRegistration = getServerRegistrationName(interfaceDeclaration)
         val connectionFactory = resolve("BTC.CAB.ServiceComm.NET.SingleQueue.ZeroMQ.NetMQ.NetMqConnectionFactory")
+        val scv_V0_6 = getTargetVersion() == ServiceCommVersion.V0_6
 
         // explicit resolution of necessary assemblies
         resolve("BTC.CAB.Logging.API.NET.ILoggerFactory")
+        resolve("BTC.CAB.ServiceComm.NET.API.IServiceFaultHandlerManagerFactory")
         resolve("BTC.CAB.ServiceComm.NET.Base.AServiceDispatcherBase")
         resolve("BTC.CAB.ServiceComm.NET.Common.IExtensible")
         resolve("BTC.CAB.ServiceComm.NET.ExtensionAPI.IServerFailureObservable")
@@ -57,23 +60,26 @@ class TestGenerator extends GeneratorBase
                   const «resolve("System.string")» connectionString = "tcp://127.0.0.1:«Constants.DEFAULT_PORT»";
                   
                   var loggerFactory = new «loggerFactory»();
+                  «IF !scv_V0_6»
+                      var serviceFaultHandlerManagerFactory = new «serviceFaultHandlerManagerFactory»();
+                  «ENDIF»
                   
                   // server
-                  StartServer(loggerFactory, connectionString);
+                  StartServer(loggerFactory«IF !scv_V0_6», serviceFaultHandlerManagerFactory«ENDIF», connectionString);
                   
                   // client
                   var connectionOptions = «connectionFactory».«resolve("BTC.CAB.ServiceComm.NET.SingleQueue.ZeroMQ.API.ConnectionOptions").alias("DefaultClientConnectionOptions")»;
                   «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.API.IConnectionFactory")» connectionFactory = new «connectionFactory»(connectionOptions, loggerFactory);
-                  _client = new «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.Core.Client")»(connectionString, new «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.Core.AsyncRpcClientEndpoint")»(loggerFactory), connectionFactory);
+                  _client = new «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.Core.Client")»(connectionString, new «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.Core.AsyncRpcClientEndpoint")»(loggerFactory«IF !scv_V0_6», serviceFaultHandlerManagerFactory«ENDIF»), connectionFactory);
                   
                   _testSubject = «resolve(interfaceDeclaration, ProjectType.PROXY).alias(getProxyFactoryName(interfaceDeclaration))».CreateProtobufProxy(_client.ClientEndpoint);
                }
             
-               private void StartServer(«loggerFactory» loggerFactory, string connectionString)
+               private void StartServer(«loggerFactory» loggerFactory«IF !scv_V0_6», «serviceFaultHandlerManagerFactory» serviceFaultHandlerManagerFactory«ENDIF», string connectionString)
                {
                    var connectionOptions = «connectionFactory».«resolve("BTC.CAB.ServiceComm.NET.SingleQueue.ZeroMQ.API.ConnectionOptions").alias("DefaultServerConnectionOptions")»;
                   _serverConnectionFactory = new «connectionFactory»(connectionOptions, loggerFactory);
-                  _server = new Server(connectionString, new «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.Core.AsyncRpcServerEndpoint")»(loggerFactory), _serverConnectionFactory);
+                  _server = new Server(connectionString, new «resolve("BTC.CAB.ServiceComm.NET.SingleQueue.Core.AsyncRpcServerEndpoint")»(loggerFactory«IF !scv_V0_6», serviceFaultHandlerManagerFactory«ELSE»«ENDIF»), _serverConnectionFactory);
                   _serverRegistration = new «serverRegistration»(_server);
                   _serverRegistration.RegisterService();
                   // ensure that the server runs when the client is created.


### PR DESCRIPTION
ServerRunner and ClientConsole work together (Not implemented exception), however there are heartbeat-exceptions logged.