### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note: All generated C++ code, and the Proxy/Dispatcher/Codec modules generated b
 | Target technology | Main dependency          | Supported versions |
 | ----------------- | ---------------          | ------------------ |
 | C++               | BTC.CAB.ServiceComm[.SQ] | cpp.servicecomm: 0.10, 0.11, 0.12 |
-| .NET              | BTC.CAB.ServiceComm.NET  | 0.6 |
+| .NET              | BTC.CAB.ServiceComm.NET  | dotnet.servicecomm: 0.6, 0.7 |
 | Java              | BTC.CAB.ServiceComm.Java | java.servicecomm: 0.3, 0.5 |
 
 The default version is always the most recent version. An older version may be specified for the command line generator with the `-versions` parameter, e.g.


### PR DESCRIPTION
to reflect new dotnet.serviceomm version parameter, and the new default (0.7)